### PR TITLE
add resolver_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.3.0] - 2023-12-04
+
+### Added
+* Add resolver options
+
 ## [v1.2.0] - 2023-08-21
 
 ### Added
@@ -29,7 +34,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Initial release
 
-[Unreleased]: https://github.com/markt-de/puppet-foreman_network/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/markt-de/puppet-foreman_network/compare/v1.3.0...HEAD
+[v1.3.0]: https://github.com/markt-de/puppet-foreman_network/compare/v1.2.0...v1.3.0
 [v1.2.0]: https://github.com/markt-de/puppet-foreman_network/compare/v1.1.0...v1.2.0
 [v1.1.0]: https://github.com/markt-de/puppet-foreman_network/compare/v1.0.0...v1.1.0
 [v1.0.0]: https://github.com/markt-de/puppet-foreman_network/tree/v1.0.0

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   * [Configure nameservers](#configure-nameservers)
     + [Additional nameservers](#additional-nameservers)
     + [Custom nameservers](#custom-nameservers)
+  * [Configure resolv options](#configure-resolv-options)
   * [Overwrite network routes](#overwrite-network-routes)
     + [Add static route and overwrite the default gateway on interface eth0](#add-static-route-and-overwrite-the-default-gateway-on-interface-eth0)
 - [Reference](#reference)
@@ -58,6 +59,7 @@ class { 'foreman_network':
   manage_network_interface_restart => true,
   manage_if_from_facts_only        => true,
   resolv_conf_path                 => '/etc/resolv.conf',
+  resolver_options                 => [],
   debug                            => false,
   searchpath_merge                 => true,
   searchpath                       => [],
@@ -75,6 +77,7 @@ foreman_network:
   manage_network_interface_restart: true
   manage_if_from_facts_only: true
   resolv_conf_path: /etc/resolv.conf
+  resolver_options: []
   debug: false
   searchpath_merge: true
   searchpath: []
@@ -151,6 +154,30 @@ nameserver 8.8.8.8
 nameserver 4.4.4.4
 [...]
 ```
+
+### Configure resolv options
+
+Add some resolver options to /etc/resolv.conf
+
+```
+class { 'foreman_network':
+  resolver_options => [
+    'timeout:1',
+    'rotate'
+  ],
+}
+```
+
+Using Hiera:
+
+```
+foreman_network:
+  resolver_options:
+    - timeout:1
+    - rotate
+```
+
+If a top scope variable `$resolver_options` exists (e.g. from Foreman ENC) it will be merged into your defined options here. This way you can tune your settings according to your infrastructure.
 
 ### Overwrite network routes
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -31,6 +31,7 @@ The following parameters are available in the `foreman_network` class:
 * [`nameservers`](#-foreman_network--nameservers)
 * [`nameservers_merge`](#-foreman_network--nameservers_merge)
 * [`resolv_conf_path`](#-foreman_network--resolv_conf_path)
+* [`resolver_options`](#-foreman_network--resolver_options)
 * [`route_overrides`](#-foreman_network--route_overrides)
 * [`searchpath`](#-foreman_network--searchpath)
 * [`searchpath_merge`](#-foreman_network--searchpath_merge)
@@ -93,6 +94,12 @@ If true merges the entries the foreman dns servers with nameservers. if false th
 Data type: `Stdlib::Absolutepath`
 
 The path of the resolv.conf. For docker accaptance test this could be modified
+
+##### <a name="-foreman_network--resolver_options"></a>`resolver_options`
+
+Data type: `Array`
+
+ENC node parameter with key resolver_options injected by foreman
 
 ##### <a name="-foreman_network--route_overrides"></a>`route_overrides`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,6 +6,7 @@ foreman_network::route_overrides: {}
 foreman_network::manage_network_interface_restart: true
 foreman_network::manage_if_from_facts_only: true
 foreman_network::resolv_conf_path: /etc/resolv.conf
+foreman_network::resolver_options: []
 foreman_network::debug: false
 foreman_network::searchpath_merge: true
 foreman_network::searchpath: []

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,9 @@
 # @param resolv_conf_path
 #   The path of the resolv.conf. For docker accaptance test this could be modified
 #
+# @param resolver_options
+#   ENC node parameter with key resolver_options injected by foreman
+#
 # @param route_overrides
 #   Overrides the default route provided by foreman and could also add additional static network routes.
 #   IMPORTANT: If DHCP enabled is enabled on the primary interface. All routes on the primary interface will be ignored.
@@ -46,6 +49,7 @@ class foreman_network (
   Boolean $manage_network_interface_restart,
   Boolean $manage_if_from_facts_only,
   Stdlib::Absolutepath $resolv_conf_path,
+  Array $resolver_options,
   Boolean $debug,
   Boolean $searchpath_merge,
   Array $searchpath,
@@ -93,9 +97,18 @@ class foreman_network (
     else {
       $real_searchpath = $foreman_searchpath
     }
+
+    if defined('$::resolver_options') {
+      $real_resolver_options = flatten($::resolver_options, $resolver_options)
+    }
+    else {
+      $real_resolver_options = flatten($resolver_options)
+    }
+
     $network_resolv_conf = {
       'nameservers' => $real_nameservers,
       'searchpath' => $real_searchpath,
+      'options' => $real_resolver_options,
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "markt-foreman_network",
-  "version": "1.2.0",
+  "version": "1.3.0-rc0",
   "author": "markt.de",
   "summary": "Puppet Module to configure network interfaces, routes and resolv.conf with Foreman ENC network interface data",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "markt-foreman_network",
-  "version": "1.3.0-rc0",
+  "version": "1.3.0",
   "author": "markt.de",
   "summary": "Puppet Module to configure network interfaces, routes and resolv.conf with Foreman ENC network interface data",
   "license": "Apache-2.0",


### PR DESCRIPTION
hand over foreman injected `resolver_options` to `saz/resolv_conf`

note that we don't validation options as `saz/resolv_conf` doesn't do either; it's `resolv_conf`'s duty to do so, so we don't cut it short to not break compatibility here.